### PR TITLE
Fix weird glyphs overlaying map

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM node:16.11.0-alpine3.13
 
+# Install MS fonts into the docker container to avoid glyphs showing.
+# See https://github.com/Delwing/discord-mudlet-map/issues/2
+RUN apk add --no-cache msttcorefonts-installer fontconfig
+RUN update-ms-fonts && fc-cache -f
+
 COPY --chown=node main.js package.json package-lock.json /app/
 RUN mkdir /app/downloads/ && chown -R node /app/downloads/
 WORKDIR /app/


### PR DESCRIPTION
If the proper font is missing (currently, "Arial" is hard-coded), it
draws weird stuff over the actual map. Installing the font will fix
this. However, we should try to find a fix soon, as the licensing of
these Fonts is problematic.