### PR TITLE
Run npm ci on image creation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN mkdir /app/downloads/ && chown -R node /app/downloads/
 RUN touch .env && chown node .env
 WORKDIR /app/
 USER node
-RUN npm install
+RUN npm ci
 
 VOLUME /app/.env
 VOLUME /app/downloads


### PR DESCRIPTION
This makes sure we use the exact versions we used in our test environment,
so we get consistent builds.